### PR TITLE
Fix bad import in calculator tool example

### DIFF
--- a/docs/content/tutorials/bring_your_own_reasoning_agent.md
+++ b/docs/content/tutorials/bring_your_own_reasoning_agent.md
@@ -79,7 +79,7 @@ Let's walk through the process of creating a custom tool, using a simple calcula
 First, we'll create the tool function:
 
 ```python
-from xrx_agent_framework import observability_decorator
+from agent_framework import observability_decorator
 
 @observability_decorator(name="calculator")
 def calculator(operation: str, x: float, y: float) -> str:


### PR DESCRIPTION
In the repo structure, the package is just called "agent_framework" ... this example is out of date. Maybe internally you guys have a repository that you pull from where you have the xrx_agent_framework package published, but in the OSS project the submodule structure just has an "agent_framework" directory in the xrx-core submodule.

It's not a big deal but it did make me question if there was some pypi package that I should reference instead of the submodule. So it's probably still worth correcting :).