### PR TITLE
filter tool output messages from conversation history on subsequent turns

### DIFF
--- a/orchestrator/src/Session.ts
+++ b/orchestrator/src/Session.ts
@@ -445,7 +445,7 @@ export class Session {
             session: { [key: string]: string };
             action?: any;
         } = {
-            messages: this.chatHistory.slice(-MAX_AGENT_MESSAGES),
+            messages: this.chatHistory.filter(m => m.content && m.role !== 'tool').slice(-MAX_AGENT_MESSAGES),
             session: this.sessionDict
         };
 


### PR DESCRIPTION
Fixes #22.

When building conversation history, filter out any messages that are type `tool` or do not have `content`.