### PR TITLE
Update requirements.txt to httpx version compatible with proxies keyword

### DIFF
--- a/stt/requirements.txt
+++ b/stt/requirements.txt
@@ -1,3 +1,4 @@
+httpx==0.27.2
 faster-whisper==1.0.3
 websockets==12.0
 numpy==1.26.4


### PR DESCRIPTION
Trying to run any apps with the current or earlier version of xRx and Groq for STT will cause an error due to a dependency issue.

There was a breaking change in ​httpx​ v0.28.0 that impacts Groq library. The ​proxies​ parameter was removed in this version, which impacts SDK functionality.

When httpx is v0.28.0 or later, Groq library gives error `TypeError: Client.__init__() got an unexpected keyword argument 'proxies'`. So running any app gives the following error when trying to use Groq for STT:

Result:
```xrx-stt           |   File "/stt/groq_stt.py", line 71, in transcribe
xrx-stt           |     model = self.get_model()  # Get the shared model instance
xrx-stt           |   File "/stt/groq_stt.py", line 22, in get_model
xrx-stt           |     cls._model = Groq(api_key=API_KEY)
xrx-stt           |   File "/usr/local/lib/python3.10/site-packages/groq/_client.py", line 99, in __init__
xrx-stt           |     super().__init__(
xrx-stt           |   File "/usr/local/lib/python3.10/site-packages/groq/_base_client.py", line 824, in __init__
xrx-stt           |     self._client = http_client or SyncHttpxClientWrapper(
xrx-stt           |   File "/usr/local/lib/python3.10/site-packages/groq/_base_client.py", line 722, in __init__
xrx-stt           |     super().__init__(**kwargs)
xrx-stt           | TypeError: Client.__init__() got an unexpected keyword argument 'proxies'```

Fix:
The fix is simple. We install latest version of httpx still compatible with other dependencies in the package. (`httpx==0.27.2`). This was the version likely used when the framework was developed but was not set in the requirements.txt. The issue is resolved with this change.